### PR TITLE
GitHub Pagesデプロイ専用のビルドコマンドを設定

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build
         working-directory: ./frontend
-        run: npm run build
+        run: npm run build:pages
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
- deploy-pages.ymlでnpm run build:pagesを使用するように変更
- プロダクションモードでのビルドを明示的に指定
- GitHub Pages環境に最適化されたビルド設定を適用