### PR TITLE
fix: GitHub PagesでfaviconのパスをベースURLに対応

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
+    <link rel="alternate icon" href="./vite.svg" />
+    <link rel="mask-icon" href="./vite.svg" color="#646cff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>hello world</title>
 


### PR DESCRIPTION
- faviconのパスを絶対パス(/vite.svg)から相対パス(./vite.svg)に変更
- ブラウザ互換性向上のためにalternate iconとmask-iconを追加
- OGPタグも併せて追加してSNSシェア対応を改善