### PR TITLE
ヘッダーのSVGアイコンをreact-iconsに変更

### DIFF
--- a/web/src/components/ui/header.tsx
+++ b/web/src/components/ui/header.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import Link from "next/link";
+import { FaGithub } from "react-icons/fa";
+import { MdEmail } from "react-icons/md";
 
 const Header: React.FC = () => {
   return (
@@ -25,14 +27,7 @@ const Header: React.FC = () => {
             className="text-white hover:text-[#4A90E2] transition-colors duration-300"
             aria-label="GitHub"
           >
-            <svg
-              className="w-6 h-6"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.74[...]" />
-            </svg>
+            <FaGithub className="w-6 h-6" />
           </a>
 
           {/* Yahoo メール リンク */}
@@ -41,14 +36,7 @@ const Header: React.FC = () => {
             className="text-white hover:text-[#4A90E2] transition-colors duration-300"
             aria-label="Yahoo Mail"
           >
-            <svg
-              className="w-6 h-6"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path d="M24 5.457v13.909c0 .904-.732 1.636-1.636 1.636h-3.819V11.73L12 16.64l-6.545-4.91v9.273H1.636A1.636 1.636 0 0 1 0 19.366V5.457c0-2.023 2.309-3.178 3.927-1.964L5.455 4.64 12 9[...]" />
-            </svg>
+            <MdEmail className="w-6 h-6" />
           </a>
         </nav>
       </div>


### PR DESCRIPTION
## 概要
ヘッダーで使用されているSVGアイコンをreact-iconsライブラリのアイコンに変更しました。

## 変更内容
- GitHubアイコン: SVG → `FaGithub` (react-icons/fa)
- メールアイコン: SVG → `MdEmail` (react-icons/md)

## 変更理由
- SVGのハードコーディングはメンテナンスが困難
- react-iconsを使用することで統一性とメンテナンス性が向上
- 既にreact-iconsはpackage.jsonに含まれているため、新たな依存関係の追加なし

## 期待される効果
- メンテナンス性の向上
- アイコンスタイルの統一性
- コードの可読性向上
- バンドルサイズの最適化（必要なアイコンのみインポート）

## 確認事項
- [x] ESLintエラーなし
- [x] TypeScriptコンパイルエラーなし
- [x] 既存の機能に影響なし

Closes #21